### PR TITLE
Refactored QuoteMachine into smaller Components

### DIFF
--- a/src/quote-machine.js
+++ b/src/quote-machine.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDom from "react-dom";
 import "./style.css";
-import QUOTES from "./quotes";
+import { Quote, NewQuoteButton } from "./quotes";
 
 export default class QuoteMachine extends React.Component {
   constructor(props) {
@@ -10,20 +10,23 @@ export default class QuoteMachine extends React.Component {
   render() {
     return (
       <div id="quote-box">
-        <div id="text">
-          <h1>
-            "Upon the requirement that a large vocabulary might need be observed
-            for little more reason than to fill a void, increasing the volume of
-            included text may be of greater than average assistance."
-          </h1>
-          {/*<h1>"When all you need is a line, connect the dots."</h1>*/}
-          <div id="author">- Myself, I. M.e.</div>
-        </div>
-        <button id="new_quote">New Quote</button>
-        <div id="share_links">
-          <img src="https://img.shields.io/badge/twitter-%1DA1F2.svg?style=social&logo=twitter&logoColor=#1DA1F2" />
-          <img src="https://img.shields.io/badge/facebook-%1877F2.svg?style=social&logo=facebook&logoColor=#1877F2" />
-        </div>
+        <Quote />
+        <NewQuoteButton clickHandler={this.handleClick.bind(this)} />
+        <ShareLinks />
+      </div>
+    );
+  }
+}
+
+class ShareLinks extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <div id="share_links">
+        <img src="https://img.shields.io/badge/twitter-%1DA1F2.svg?style=social&logo=twitter&logoColor=#1DA1F2" />
+        <img src="https://img.shields.io/badge/facebook-%1877F2.svg?style=social&logo=facebook&logoColor=#1877F2" />
       </div>
     );
   }

--- a/src/quotes.js
+++ b/src/quotes.js
@@ -1,4 +1,6 @@
-export const QUOTES = [
+import React from "react";
+
+const QUOTES = [
   {
     text: "Upon the requirement that a large vocabulary might need be observed for little more reason than to fill a void, increasing the volume of included text may be of greater than average assistance.",
     author: "Myself, I. M.e.",
@@ -8,3 +10,30 @@ export const QUOTES = [
     author: "Myself, I. M.e.",
   },
 ];
+
+export class Quote extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <div id="text">
+        <h1>
+          "Upon the requirement that a large vocabulary might need be observed
+          for little more reason than to fill a void, increasing the volume of
+          included text may be of greater than average assistance."
+        </h1>
+        <div id="author">- Myself, I. M.e.</div>
+      </div>
+    );
+  }
+}
+
+export class NewQuoteButton extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return <button id="new_quote">New Quote</button>;
+  }
+}


### PR DESCRIPTION
The HTML rendered by the `QuoteMachine` class was reduced to three React Components

- Quote
- NewQuoteButton
- ShareLinks

The first two were moved to `quotes.js`, and the `QUOTES` array is no longer exported directly. The third is really just for readability in `QuuoteMachine`, but it also serves as a place to add other sharing capabilities in future versions.